### PR TITLE
Do not swallow output from `bundle install`.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,14 +56,10 @@ OVERRIDE_GH_PAGES_BRANCH=${INPUT_OVERRIDE_GH_PAGES_BRANCH:-${OVERRIDE_GH_PAGES_B
 # Default: `true`
 GH_PAGES_ADD_NO_JEKYLL=${INPUT_GH_PAGES_ADD_NO_JEKYLL:-${GH_PAGES_ADD_NO_JEKYLL:-true}}
 
-echo "Installing gem bundle..."
-# Prevent installed dependencies messages from clogging the log
-bundle install > /dev/null 2>&1
+bundle install
 
 # Check if jekyll is installed
 bundle list | grep "jekyll ("
-
-echo "Successfully installed gem bundles!"
 
 echo "Pushing to GitHub Pages..."
 


### PR DESCRIPTION
Redirecting stdout and stderr to `/dev/null` makes it impossible to
troubleshoot issues with the `bundle install` step of the build.

Please consider merging this PR so as to make it far easier for users of your GitHub Action to see full build logs. Far from "clogging" the output of the log, the output of `bundle install` provides a vitally important diagnostic to determine the health of a given build attempt.