### PR TITLE
Show `bundle install` output if the installation exits non-zero.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,8 +57,11 @@ OVERRIDE_GH_PAGES_BRANCH=${INPUT_OVERRIDE_GH_PAGES_BRANCH:-${OVERRIDE_GH_PAGES_B
 GH_PAGES_ADD_NO_JEKYLL=${INPUT_GH_PAGES_ADD_NO_JEKYLL:-${GH_PAGES_ADD_NO_JEKYLL:-true}}
 
 echo "Installing gem bundle..."
-# Prevent installed dependencies messages from clogging the log
-bundle install > /dev/null 2>&1
+
+if [[ 0 -ne $(bundle install > /tmp/bundle-install.log 2>&1; echo $?) ]]; then
+    echo "Failed to install gem bundles:"
+    cat /tmp/bundle-install.log
+fi
 
 # Check if jekyll is installed
 bundle list | grep "jekyll ("


### PR DESCRIPTION
Based on the feedback in #5, here's an alternative version that does not require adding a flag but still shows the `bundle install` output if (and only if) an error occurs during the Gem installation step, massively simplifying troubleshooting in case of build errors. No flag to enable, just view the build log and if there's an error, the `bundle install` output will describe what it is. If there's no error, then the `bundle install` output won't "clog" the log.

CC: @jhoward321