### PR TITLE
Allow passing options to the `jekyll build` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ steps:
       gh_pages_branch: 'gh-pages' # The GitHub Pages branch to deploy the site to
       gh_pages_dist_folder: '_site' # The folder to build the site to
       gh_pages_commit_message: 'Deploy commit $GITHUB_SHA\n\nAutodeployed using $GITHUB_ACTION in $GITHUB_WORKFLOW' # The commit message to use when deploying the site
+      jekyll_build_opts: '' # Options to pass to the Jekyll build command.
       remote_repo: 'https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git' # The repository to deploy the site to
       committer_username: '$GITHUB_ACTOR' # The username to use for the committer of the commit
       committer_email: '${GITHUB_ACTOR}@users.noreply.github.com' # The email to use for the committer of the commit

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,8 @@ inputs:
     description: 'The commit message to use when deploying the Jekyll site.'
   remote_repo:
     description: 'The repository to deploy the Jekyll site to.'
+  jekyll_build_opts:
+    description: 'Options to pass to the Jekyll build command.'
   committer_username:
     description: 'The username to use for the committer of the commit.'
   committer_email:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,7 @@ GITHUB_TOKEN=${INPUT_GITHUB_TOKEN:-$GITHUB_TOKEN}
 
 # Specifies the Git remote repository
 REMOTE_REPO=${INPUT_REMOTE_REPO:-${REMOTE_REPO:-"https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"}}
+
 # Specifies the committer's username
 # Default: $GITHUB_ACTOR
 COMMITTER_USERNAME=${INPUT_COMMITTER_USERNAME:-${COMMITTER_USERNAME:-$GITHUB_ACTOR}}
@@ -41,6 +42,9 @@ GIT_FORCE=${INPUT_GIT_FORCE:-${GIT_FORCE:-true}}
 
 # Whether to override the contents of the branch with the current build
 OVERRIDE_GH_PAGES_BRANCH=${INPUT_OVERRIDE_GH_PAGES_BRANCH:-${OVERRIDE_GH_PAGES_BRANCH:-false}}
+
+# Specifies the Jekyll build command
+JEKYLL_BUILD_OPTS="${INPUT_JEKYLL_BUILD_OPTS:-${JEKYLL_BUILD_OPTS}}"
 
 # Whether to add the `.nojekyll` file to indicate that the branch should not be built
 # Default: `true`
@@ -80,7 +84,7 @@ if [[ -n "$JEKYLL_BUILD_PRE_COMMANDS" ]]; then
   echo "Running pre-build commands..."
   eval "$JEKYLL_BUILD_PRE_COMMANDS"
 fi
-bundle exec jekyll build
+bundle exec jekyll build "$JEKYLL_BUILD_OPTS"
 echo "Successfully built the site!"
 
 if [[ -d "$GH_PAGES_DIST_FOLDER" ]]; then


### PR DESCRIPTION
This commit makes it possible to, for instance, build future-dated posts
using the Jekyll `--future` flag or any other combination of Jekyll
build command options.