### PR TITLE
Remove commented code, specify "commit" or "build" on pre/post commands.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,23 +4,10 @@ set -e
 
 # Environment variables
 
-# Specifies the type of repository
-# Valid values:
-# - `project`
-# - `user`
-# Default: `project`
-# DEPRECATED: Please use GH_PAGES_BRANCH instead which allows for more configuration.
-# if [[ -n "$GH_PAGES_TYPE" ]]; then
-  # echo -e "DEPRECATED: Please use the GH_PAGES_BRANCH environment variable instead of GH_PAGES_TYPE.\nThis may be removed in a future release."
-  # if [[ "$GH_PAGES_TYPE" = "project" ]]; then
-    # GH_PAGES_BRANCH="gh-pages"
-  # elif [[ "$GH_PAGES_TYPE" = "user" ]]; then
-    # GH_PAGES_BRANCH="master"
-  # fi
-# fi
 # Specifies the branch to deploy to
 # Default: `gh-pages`
 GH_PAGES_BRANCH=${INPUT_GH_PAGES_BRANCH:-${GH_PAGES_BRANCH:-"gh-pages"}}
+
 # Specifies the folder that Jekyll builds to
 # Default: `_site`
 GH_PAGES_DIST_FOLDER=${INPUT_GH_PAGES_DIST_FOLDER:-${GH_PAGES_DIST_FOLDER:-"_site"}}
@@ -31,16 +18,19 @@ if [[ -n "$GH_PAGES_MESSAGE" ]]; then
 fi
 # Specifies the commit message
 GH_PAGES_COMMIT_MESSAGE=${INPUT_GH_PAGES_COMMIT_MESSAGE:-${GH_PAGES_COMMIT_MESSAGE:-"Deploy commit $GITHUB_SHA\n\nAutodeployed using $GITHUB_ACTION in $GITHUB_WORKFLOW"}}
+
 # GitHub Pages token for deploying
 GH_PAGES_TOKEN=${INPUT_GH_PAGES_TOKEN:-$GH_PAGES_TOKEN}
+
 # GitHub token
 GITHUB_TOKEN=${INPUT_GITHUB_TOKEN:-$GITHUB_TOKEN}
+
 # Specifies the Git remote repository
-# REMOTE_REPO=${REMOTE_REPO:-"https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"}
 REMOTE_REPO=${INPUT_REMOTE_REPO:-${REMOTE_REPO:-"https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"}}
 # Specifies the committer's username
 # Default: $GITHUB_ACTOR
 COMMITTER_USERNAME=${INPUT_COMMITTER_USERNAME:-${COMMITTER_USERNAME:-$GITHUB_ACTOR}}
+
 # Specifies the committer's email
 # Default: `${GITHUB_ACTOR}@users.noreply.github.com`
 COMMITTER_EMAIL=${INPUT_COMMITTER_EMAIL:-${COMMITTER_EMAIL:-"${GITHUB_ACTOR}@users.noreply.github.com"}}
@@ -70,9 +60,6 @@ echo "Pushing to GitHub Pages..."
 if [[ -d "$GH_PAGES_DIST_FOLDER" ]]; then
   rm -rf "$GH_PAGES_DIST_FOLDER"
   mkdir "$GH_PAGES_DIST_FOLDER"
-# else
-  # echo "The dist folder doesn't exist! Either you did not set GH_PAGES_DIST_FOLDER properly, or you changed the destination in the Jekyll configuration!"
-  # exit 1
 fi
 
 echo "Cloning repository locally..."
@@ -86,7 +73,7 @@ if [[ "$OVERRIDE_GH_PAGES_BRANCH" = true || ($OVERRIDE_GH_PAGES_BRANCH = 1) ]]; 
 fi
 
 if [[ -n "$JEKYLL_BUILD_PRE_COMMANDS" ]]; then
-  echo "Running pre commands..."
+  echo "Running pre-build commands..."
   eval "$JEKYLL_BUILD_PRE_COMMANDS"
 fi
 bundle exec jekyll build
@@ -104,12 +91,12 @@ if [[ "$GH_PAGES_ADD_NO_JEKYLL" = true || ($GH_PAGES_ADD_NO_JEKYLL == 1) ]]; the
   echo "" > .nojekyll
 fi
 if [[ -n "$JEKYLL_BUILD_POST_COMMANDS" ]]; then
-  echo "Running post commands..."
+  echo "Running post-build commands..."
   eval "$JEKYLL_BUILD_POST_COMMANDS"
 fi
 
 if [[ -n "$GH_PAGES_COMMIT_PRE_COMMANDS" ]]; then
-  echo "Running pre commands..."
+  echo "Running pre-commit commands..."
   eval "$GH_PAGES_COMMIT_PRE_COMMANDS"
 fi
 echo "Setting Git username and email..."
@@ -118,7 +105,6 @@ git config user.email "$COMMITTER_EMAIL"
 
 echo "Committing all files..."
 git add -A
-# echo -n "Files to commit: " && ls -l | wc -l
 
 git commit -m "$(echo -e "$GH_PAGES_COMMIT_MESSAGE")"
 if [[ "$GIT_FORCE" = true || ($GIT_FORCE == 1) ]]; then
@@ -130,7 +116,7 @@ else
 fi
 
 if [[ -n "$GH_PAGES_COMMIT_POST_COMMANDS" ]]; then
-  echo "Running post commands..."
+  echo "Running post-commit commands..."
   eval "$GH_PAGES_COMMIT_POST_COMMANDS"
 fi
 


### PR DESCRIPTION
This commit makes no functional change other than letting the build log
know whether the "pre" or "post" command being run is related to the
pre-commit or pre-build (or post-commit or post-build) section. Prior to
this commit, the build log included two identical lines reading "Running
pre commands..." but after this commit, the build log will say
explicitly whether those commands are pre-BUILD or pre-COMMIT commands.

This commit also just cleans up many chunks of commented-out code that
perform no active function.