### PR TITLE
Add flag for showing full bundle install log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ steps:
       override_gh_pages_branch: 'false' # Whether to override the gh-pages branch on push
       gh_pages_add_no_jekyll: 'true' # Whether to add the .nojekyll file to the deployed site
       skip_deploy: 'false' # Whether to skip deployment after a successful build.
+      show_bundle_log: 'false' # Whether to show detailed logs from bundle install command. Useful for debugging broken builds.
 ```

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   skip_deploy:
     description: 'Whether to skip deployment after a successful build.'
     default: 'false'
+  show_bundle_log:
+    description: 'Whether to show detailed logs from the bundle install command.'
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,9 +54,16 @@ GH_PAGES_ADD_NO_JEKYLL=${INPUT_GH_PAGES_ADD_NO_JEKYLL:-${GH_PAGES_ADD_NO_JEKYLL:
 # Default: `false`
 SKIP_DEPLOY=${INPUT_SKIP_DEPLOY:-${SKIP_DEPLOY:-false}}
 
+# Whether to show the full bundle install log
+SHOW_BUNDLE_LOG=${INPUT_SHOW_BUNDLE_LOG:-${SHOW_BUNDLE_LOG:-false}}
+
 echo "Installing gem bundle..."
-# Prevent installed dependencies messages from clogging the log
-bundle install > /dev/null 2>&1
+if [[ "$SHOW_BUNDLE_LOG" = true || ($SHOW_BUNDLE_LOG == 1) ]]; then
+  bundle install
+else
+  # Prevent installed dependencies messages from clogging the log
+  bundle install > /dev/null 2>&1
+fi
 
 # Check if jekyll is installed
 bundle list | grep "jekyll ("


### PR DESCRIPTION
This adds a flag for showing the full bundle install log. I will add a separate PR for skipping deployment.