### PR TITLE
Add support for specifying the Jekyll build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,5 @@ steps:
       skip_deploy: 'false' # Whether to skip deployment after a successful build.
       show_bundle_log: 'false' # Whether to show detailed logs from bundle install command. Useful for debugging broken builds.
       bundler_version: '' # A specific version of Bundler to be used.
+      jekyll_env: 'production' # The Jekyll environment to use when building the site. (See https://jekyllrb.com/docs/configuration/environments/)
 ```

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,10 @@ inputs:
   bundler_version:
     description: 'A specific version of Bundler to be used.'
     required: false
+  jekyll_env:
+    description: 'The Jekyll environment to use when building the site. (See https://jekyllrb.com/docs/configuration/environments/)'
+    default: 'production'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,9 @@ SHOW_BUNDLE_LOG=${INPUT_SHOW_BUNDLE_LOG:-${SHOW_BUNDLE_LOG:-false}}
 # The specific version of Bundler to install.
 BUNDLER_VERSION=${INPUT_BUNDLER_VERSION:-${BUNDLER_VERSION}}
 
+# The environment to use for the build
+JEKYLL_ENV=${INPUT_JEKYLL_ENV:-${JEKYLL_ENV}}
+
 echo "Updating gems..."
 gem update --system
 


### PR DESCRIPTION
See https://jekyllrb.com/docs/configuration/environments/ for more info

Closes #21

---
BREAKING CHANGE: Jekyll will now build your site in production mode. To
use the previous defaults (i.e. development mode), specify the
`jekyll_env` input with a value of `development`.
